### PR TITLE
refactor: Omitting the dir for cert/keys

### DIFF
--- a/example/integration_test.zig
+++ b/example/integration_test.zig
@@ -76,12 +76,11 @@ test "server without certificate" {
 
 test "server with ec key key pair" {
     const allocator = testing.allocator;
-    const dir = try std.fs.cwd().openDir("example/cert", .{});
 
-    var auth = try tls.config.CertKeyPair.load(allocator, dir, "localhost_ec/cert.pem", "localhost_ec/key.pem");
+    var auth = try tls.config.CertKeyPair.load(allocator, "example/cert/localhost_ec/cert.pem", "example/cert/localhost_ec/key.pem");
     defer auth.deinit(allocator);
 
-    var root_ca = try tls.config.CertBundle.fromFile(allocator, dir, "minica.pem");
+    var root_ca = try tls.config.CertBundle.fromFile(allocator, "example/cert/minica.pem");
     defer root_ca.deinit(allocator);
 
     const opt: tls.config.Server = .{ .auth = &auth };
@@ -101,12 +100,11 @@ test "server with ec key key pair" {
 
 test "server with rsa key key pair" {
     const allocator = testing.allocator;
-    const dir = try std.fs.cwd().openDir("example/cert", .{});
 
-    var auth = try tls.config.CertKeyPair.load(allocator, dir, "localhost_rsa/cert.pem", "localhost_rsa/key.pem");
+    var auth = try tls.config.CertKeyPair.load(allocator, "example/cert/localhost_rsa/cert.pem", "example/cert/localhost_rsa/key.pem");
     defer auth.deinit(allocator);
 
-    var root_ca = try tls.config.CertBundle.fromFile(allocator, dir, "minica.pem");
+    var root_ca = try tls.config.CertBundle.fromFile(allocator, "example/cert/minica.pem");
     defer root_ca.deinit(allocator);
 
     const opt: tls.config.Server = .{ .auth = &auth };
@@ -126,12 +124,11 @@ test "server with rsa key key pair" {
 
 test "server request client authentication" {
     const allocator = testing.allocator;
-    const dir = try std.fs.cwd().openDir("example/cert", .{});
 
-    var auth = try tls.config.CertKeyPair.load(allocator, dir, "localhost_rsa/cert.pem", "localhost_rsa/key.pem");
+    var auth = try tls.config.CertKeyPair.load(allocator, "example/cert/localhost_rsa/cert.pem", "example/cert/localhost_rsa/key.pem");
     defer auth.deinit(allocator);
 
-    var root_ca = try tls.config.CertBundle.fromFile(allocator, dir, "minica.pem");
+    var root_ca = try tls.config.CertBundle.fromFile(allocator, "example/cert/minica.pem");
     defer root_ca.deinit(allocator);
 
     const opt: tls.config.Server = .{
@@ -152,9 +149,10 @@ test "server request client authentication" {
 
     // client with client certificate
     for (client_keys) |sub_path| {
+        const dir = try std.fs.cwd().openDir("example/cert", .{});
         const cert_dir = try dir.openDir(sub_path, .{});
 
-        var client_auth = try tls.config.CertKeyPair.load(allocator, cert_dir, "cert.pem", "key.pem");
+        var client_auth = try tls.config.CertKeyPair.load(allocator, std.fs.path.join(allocator, [][]const u8{ cert_dir, "cert.pem" }), std.fs.path.join(allocator, [][]const u8{ cert_dir, "key.pem" }));
         defer client_auth.deinit(allocator);
 
         const client_opt: tls.config.Client = .{
@@ -170,12 +168,11 @@ test "server request client authentication" {
 
 test "server require client authentication" {
     const allocator = testing.allocator;
-    const dir = try std.fs.cwd().openDir("example/cert", .{});
 
-    var auth = try tls.config.CertKeyPair.load(allocator, dir, "localhost_rsa/cert.pem", "localhost_rsa/key.pem");
+    var auth = try tls.config.CertKeyPair.load(allocator, "example/cert/localhost_rsa/cert.pem", "example/cert/localhost_rsa/key.pem");
     defer auth.deinit(allocator);
 
-    var root_ca = try tls.config.CertBundle.fromFile(allocator, dir, "minica.pem");
+    var root_ca = try tls.config.CertBundle.fromFile(allocator, "example/cert/minica.pem");
     defer root_ca.deinit(allocator);
 
     const opt: tls.config.Server = .{
@@ -196,8 +193,9 @@ test "server require client authentication" {
 
     // load client certificate and connect
     for (client_keys) |sub_path| {
+        const dir = try std.fs.cwd().openDir("example/cert", .{});
         const cert_dir = try dir.openDir(sub_path, .{});
-        var client_auth = try tls.config.CertKeyPair.load(allocator, cert_dir, "cert.pem", "key.pem");
+        var client_auth = try tls.config.CertKeyPair.load(allocator, std.fs.path.join(allocator, [][]const u8{ cert_dir, "cert.pem" }), std.fs.path.join(allocator, [][]const u8{ cert_dir, "key.pem" }));
         defer client_auth.deinit(allocator);
         const client_opt: tls.config.Client = .{
             .host = host,
@@ -212,12 +210,11 @@ test "server require client authentication" {
 
 test "server send key update" {
     const allocator = testing.allocator;
-    const dir = try std.fs.cwd().openDir("example/cert", .{});
 
-    var auth = try tls.config.CertKeyPair.load(allocator, dir, "localhost_rsa/cert.pem", "localhost_rsa/key.pem");
+    var auth = try tls.config.CertKeyPair.load(allocator, "example/cert/localhost_rsa/cert.pem", "example/cert/localhost_rsa/key.pem");
     defer auth.deinit(allocator);
 
-    var root_ca = try tls.config.CertBundle.fromFile(allocator, dir, "minica.pem");
+    var root_ca = try tls.config.CertBundle.fromFile(allocator, "example/cert/minica.pem");
     defer root_ca.deinit(allocator);
 
     const opt: tls.config.Server = .{ .auth = &auth };

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Library also has minimal, TLS 1.3 only server implementation. To upgrade tcp to 
 
 ```zig
     // Load server certificate key pair
-    var auth = try tls.config.CertKeyPair.load(allocator, dir, "localhost_ec/cert.pem", "localhost_ec/key.pem");
+    var auth = try tls.config.CertKeyPair.load(allocator, "example/cert/localhost_ec/cert.pem", "example/cert/localhost_ec/key.pem");
     defer auth.deinit(allocator);
     
     // Tcp listener

--- a/src/handshake_common.zig
+++ b/src/handshake_common.zig
@@ -49,14 +49,13 @@ pub const CertKeyPair = struct {
 
     pub fn load(
         allocator: std.mem.Allocator,
-        dir: std.fs.Dir,
         cert_path: []const u8,
         key_path: []const u8,
     ) !CertKeyPair {
         var bundle: Certificate.Bundle = .{};
-        try bundle.addCertsFromFilePath(allocator, dir, cert_path);
+        try bundle.addCertsFromFilePathAbsolute(allocator, cert_path);
 
-        const key_file = try dir.openFile(key_path, .{});
+        const key_file = try std.fs.openFileAbsolute(key_path, .{});
         defer key_file.close();
         const key = try PrivateKey.fromFile(allocator, key_file);
 
@@ -75,9 +74,9 @@ pub const CertBundle = struct {
     // forms valid trust chain.
     bundle: Certificate.Bundle = .{},
 
-    pub fn fromFile(allocator: std.mem.Allocator, dir: std.fs.Dir, path: []const u8) !CertBundle {
+    pub fn fromFile(allocator: std.mem.Allocator, path: []const u8) !CertBundle {
         var bundle: Certificate.Bundle = .{};
-        try bundle.addCertsFromFilePath(allocator, dir, path);
+        try bundle.addCertsFromFilePathAbsolute(allocator, path);
         return .{ .bundle = bundle };
     }
 


### PR DESCRIPTION
- The certs and keys might be hold in different dirs
- Having to pass a dir to load() or fromFile() doesn't feel right because cert and keys might not be in the same dir
- Passing these files by absolute path is more intuitive

I couldn't test it because of stability concern I use zig 0.13.0 and it looks like you library uses latest zig from master branch, so that some implementations are not working between std lib. Also since project don't seem to github actions for test, I couldn't get it tested.