### PR TITLE
Accept the async handler type as-is.

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -454,11 +454,11 @@ pub fn Async(comptime Handler: type, comptime HandshakeType: type, comptime Opti
         const Self = @This();
 
         allocator: mem.Allocator,
-        handler: *Handler,
+        handler: Handler,
         handshake: ?*HandshakeType = null,
         cipher: ?Cipher = null,
 
-        pub fn init(allocator: mem.Allocator, handler: *Handler, opt: Options) !Self {
+        pub fn init(allocator: mem.Allocator, handler: Handler, opt: Options) !Self {
             const handshake = try allocator.create(HandshakeType);
             errdefer allocator.destroy(handshake);
             try handshake.init(opt);


### PR DESCRIPTION
Right now, the Handler typed is forced into a pointer. But I think the Handler type should be used as-is, leaving control to the caller. The case for a non-pointer type is when the Handler is merely a wrapper. I want to do:

```zig
const TLSHandler struct {
  io: *IO,

  fn send(self: TLSHandler, data: []const u8) !void {
    return self.io.send(data);
  }

  //...
}
```

In which case, forcing a pointer isn't helpful.