### PR TITLE
Change Handler.onRecv to return a boolean to stop processing messages.

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -429,6 +429,8 @@ test "client/server connection" {
 ///
 ///   onConnect()           - notification that tls handshake is done
 ///   onRecv(cleartext)     - cleartext data to pass to the application
+///                           returning true stops any additional processing
+///                           on the buffer
 ///   send(buf)             - ciphertext to pass to the underlying tcp connection
 ///
 /// Interface provided to the handler:
@@ -556,7 +558,9 @@ pub fn Async(comptime Handler: type, comptime HandshakeType: type, comptime Opti
                 }
 
                 assert(content_type == .application_data);
-                try self.handler.onRecv(@constCast(cleartext));
+                if (try self.handler.onRecv(@constCast(cleartext)) == false) {
+                    return;
+                }
             }
             return rdr.bytesRead();
         }


### PR DESCRIPTION
I'm not sure if this makes 100% sense, but I've run into a bit of a chicken-and-egg problem trying to cleanup.

You can imagine I get a message from the server, which I pass to `tls_client.onRecv`. It calls my `TLSHandler.onRecv` with the cleartext data. Based on the data, I want to shutdown/cleanup, but cleaning up involves deallocating the buffer I passed into `tls_client.onRecv`. 

However after I cleanup and return from my`TLSHAndler.onRecv`, the TLS client will continue to try to process additional messages from the buffer, which has since been deallocated.

I currently solve this by having my `onRecv` return an error (`error.Done`) which breaks out of the TLS handling. But I'm thinking having `onRecv` return a boolean (as this PR does) would be better?

Could get fancy and support `onRecv() !void` or `onRecv() !bool` so that, at comptime, the check can be skipped.
