### PR TITLE
Allow pointer type in Connection generics

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -132,7 +132,13 @@ pub fn Connection(comptime Stream: type) type {
 
         // read, write interface
 
-        pub const ReadError = Stream.ReadError || proto.Alert.Error ||
+        const _Stream = blk: {
+            const StreamInfo = @typeInfo(Stream);
+            if (StreamInfo == .pointer) break :blk StreamInfo.pointer.child;
+            break :blk Stream;
+        };
+
+        pub const ReadError = _Stream.ReadError || proto.Alert.Error ||
             error{
                 TlsBadVersion,
                 TlsUnexpectedMessage,
@@ -143,7 +149,7 @@ pub fn Connection(comptime Stream: type) type {
                 TlsIllegalParameter,
                 TlsCipherNoSpaceLeft,
             };
-        pub const WriteError = Stream.WriteError ||
+        pub const WriteError = _Stream.WriteError ||
             error{
                 TlsCipherNoSpaceLeft,
                 TlsUnexpectedMessage,


### PR DESCRIPTION
Hi @ianic,

I'm Francis from Lightpanda. This is a small PR to allow pointer type in `tls.Connection` generics.
Our use case: passing `*tls.Connection(std.net.Stream)` type to support TLS in TLS stream (https proxy).