### PR TITLE
Add one of my self-hosted domains

### DIFF
--- a/example/domains
+++ b/example/domains
@@ -4057,6 +4057,7 @@ peakgames.net
 pearson.com
 peatix.com
 pegah.tech
+pelito.strangled.net
 pelmorex.com
 pendo.io
 people.com


### PR DESCRIPTION
I'm adding one of my domains which I host at home. Last time I tried, the std client failed with my config. I expect that's still the case for std and it might be the case for tls.zig too (didn't try because what I was coding I wanted to have no external deps), but adding it to this list gives me a chance to know when it starts working.

For the config itself, I'm using s6-tls+BearSSL with multiple domains, some using wildcard certificates and some using single-domain certs. This one is a single one. I'm not hosting anything in particular at that specific domain, but it should be enough for the handshake.