### PR TITLE
Update example documentation and README

### DIFF
--- a/example/http_get.zig
+++ b/example/http_get.zig
@@ -21,7 +21,7 @@ pub fn main() !void {
             // to force specific cipher:
             //   .cipher_suites = &[_]tls.CipherSuite{.CHACHA20_POLY1305_SHA256},
             // to force cipher from specific tls version:
-            //   .cipher_suites = tls.cipher_suites.tls12,
+            //   .cipher_suites = tls.config.cipher_suites.tls12,
             .cipher_suites = tls.config.cipher_suites.secure,
             .key_log_callback = tls.config.key_log.callback,
         });

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ To use just ciphers which are graded secure or recommended on  https://ciphersui
     var conn = try tls.clientFromStream(tcp, .{
         .host = host,
         .root_ca = root_ca,
-        .cipher_suites = tls.cipher_suites.secure,
+        .cipher_suites = tls.config.cipher_suites.secure,
     });
 ```
 `cipher_suites` can be used to force tls 1.3 only or tls 1.2 only ciphers. Or to reorder cipher preferences.


### PR DESCRIPTION
The doc comments and the readme are slightly out of date; `tls.cipher_suites` was moved to `tls.config.cipher_suites` back in c028a284, I believe. It's nothing major, but it tripped me up when I came across this repo.