### PR TITLE
Add ALPN (Application-Layer Protocol Negotiation) support for TLS 1.3

### DIFF
--- a/example/http_get.zig
+++ b/example/http_get.zig
@@ -22,6 +22,7 @@ pub fn main(init: std.process.Init) !void {
             // to force cipher from specific tls version:
             //   .cipher_suites = tls.config.cipher_suites.tls12,
             .cipher_suites = tls.config.cipher_suites.secure,
+            .alpn_protocols = &.{ "http/1.1", "h2" },
             .key_log_callback = tls.config.key_log.init(init.minimal.environ),
             .now = std.Io.Clock.real.now(io),
             .rng = rng_impl.interface(),

--- a/example/top_sites.zig
+++ b/example/top_sites.zig
@@ -68,6 +68,7 @@ pub fn run(gpa: std.mem.Allocator, io: Io, domain: []const u8, root_ca: tls.conf
         .diagnostic = &diagnostic,
         .now = std.Io.Clock.real.now(io),
         .rng = rng_impl.interface(),
+        .alpn_protocols = &.{ "http/1.1", "h2" },
     };
     if (cmn.inList(domain, &cmn.no_keyber)) {
         opt.named_groups = &[_]tls.config.NamedGroup{ .x25519, .secp256r1 };

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -28,6 +28,10 @@ pub const Connection = struct {
     session_resumption: ?*SessionResumption = null,
     session_resumption_secret_idx: ?usize = null,
 
+    /// ALPN protocol negotiated during TLS handshake (e.g., "h2", "http/1.1").
+    /// Points into static data or the options slice; valid for the connection lifetime.
+    alpn_protocol: ?[]const u8 = null,
+
     const Self = @This();
 
     /// Encrypts and writes single tls record to the stream.

--- a/src/handshake_client.zig
+++ b/src/handshake_client.zig
@@ -58,6 +58,10 @@ pub const Options = struct {
         .x25519_ml_kem768,
     },
 
+    /// ALPN protocol names to advertise (e.g., "h2", "http/1.1").
+    /// If empty, no ALPN extension is sent.
+    alpn_protocols: []const []const u8 = &.{},
+
     /// Client authentication certificates and private key.
     auth: ?*CertKeyPair = null,
 
@@ -231,6 +235,9 @@ pub const Handshake = struct {
     server_pub_key_buf: [1120]u8 = undefined,
     server_pub_key: []const u8 = undefined,
     pre_shared_selected_identity: ?u16 = null,
+    /// ALPN protocol selected by the server, copied into alpn_protocol_buf.
+    alpn_protocol: ?[]const u8 = null,
+    alpn_protocol_buf: [32]u8 = undefined,
     // statistics
     max_server_record_len: usize = 0,
     max_server_cleartext_len: usize = 0,
@@ -467,6 +474,9 @@ pub const Handshake = struct {
         try w.extension(.supported_groups, opt.named_groups);
         try w.keyShare(opt.named_groups, shared_keys);
         try w.serverName(opt.host);
+        if (opt.alpn_protocols.len > 0) {
+            try w.alpn(opt.alpn_protocols);
+        }
         // binder key placeholder
         const binder_pos: ?usize = if (resumption_ticket) |ticket| brk: {
             // Add pre shared key extension if this is session resumption. Must be last extension.
@@ -602,6 +612,16 @@ pub const Handshake = struct {
                         h.server_pub_key = try common.dupe(&h.server_pub_key_buf, try d.slice(try d.decode(u16)));
                         if (len != h.server_pub_key.len + 4) return error.TlsIllegalParameter;
                     },
+                    .application_layer_protocol_negotiation => {
+                        // RFC 7301: server ALPN response contains a single protocol
+                        // ProtocolNameList (u16 len) -> ProtocolName (u8 len + name)
+                        _ = try d.decode(u16); // protocol_name_list length
+                        const proto_len = try d.decode(u8);
+                        const proto_slice = try d.slice(proto_len);
+                        if (proto_len > h.alpn_protocol_buf.len) return error.TlsDecodeError;
+                        @memcpy(h.alpn_protocol_buf[0..proto_len], proto_slice);
+                        h.alpn_protocol = h.alpn_protocol_buf[0..proto_len];
+                    },
                     .pre_shared_key => {
                         h.pre_shared_selected_identity = try d.decode(u16);
                     },
@@ -681,7 +701,29 @@ pub const Handshake = struct {
                         }
                         switch (handshake_type) {
                             .encrypted_extensions => {
-                                try d.skip(length);
+                                // Parse extensions within EncryptedExtensions
+                                const ee_end = d.idx + length;
+                                if (length >= 2) {
+                                    const exts_len = try d.decode(u16);
+                                    const exts_end = d.idx + exts_len;
+                                    while (d.idx < exts_end) {
+                                        const ext_type = try d.decode(proto.Extension);
+                                        const ext_len = try d.decode(u16);
+                                        switch (ext_type) {
+                                            .application_layer_protocol_negotiation => {
+                                                _ = try d.decode(u16); // protocol_name_list length
+                                                const proto_len = try d.decode(u8);
+                                                const proto_slice = try d.slice(proto_len);
+                                                if (proto_len > h.alpn_protocol_buf.len) return error.TlsDecodeError;
+                                                @memcpy(h.alpn_protocol_buf[0..proto_len], proto_slice);
+                                                h.alpn_protocol = h.alpn_protocol_buf[0..proto_len];
+                                            },
+                                            else => try d.skip(ext_len),
+                                        }
+                                    }
+                                }
+                                // Skip any remaining bytes
+                                if (d.idx < ee_end) try d.skip(ee_end - d.idx);
                                 handshake_states = if (is_session_resumption)
                                     &.{ .certificate_request, .certificate, .finished }
                                 else if (h.cert.skip_verify)
@@ -1326,6 +1368,11 @@ pub const NonBlock = struct {
     /// Cipher produced in handshake, null until successful handshake.
     pub fn cipher(self: Self) ?Cipher {
         return if (self.done()) self.inner.cipher else null;
+    }
+
+    /// ALPN protocol negotiated during handshake, null if none.
+    pub fn alpnProtocol(self: Self) ?[]const u8 {
+        return self.inner.alpn_protocol;
     }
 };
 

--- a/src/handshake_server.zig
+++ b/src/handshake_server.zig
@@ -39,6 +39,10 @@ pub const Options = struct {
     /// List of supported tls 1.3 cipher suites
     cipher_suites: []const CipherSuite = cipher_suites.tls13,
 
+    /// ALPN protocol names supported by the server, in preference order.
+    /// If empty, no ALPN extension is sent in the response.
+    alpn_protocols: []const []const u8 = &.{},
+
     now: Io.Timestamp,
 };
 
@@ -82,6 +86,8 @@ pub const Handshake = struct {
 
     cipher: Cipher = undefined,
     transcript: Transcript = .{},
+    /// ALPN protocol selected during handshake.
+    alpn_protocol: ?[]const u8 = null,
 
     const Self = @This();
 
@@ -100,7 +106,7 @@ pub const Handshake = struct {
     pub fn handshake(h: *Self, opt: Options) !Cipher {
         h.initKeys(opt);
 
-        h.readClientHello(opt.cipher_suites) catch |err| {
+        h.readClientHello(opt.cipher_suites, opt.alpn_protocols) catch |err| {
             try h.writeAlert(null, err);
             return err;
         };
@@ -131,7 +137,7 @@ pub const Handshake = struct {
     }
 
     fn clientFlight1(h: *Self, opt: Options) !void {
-        try h.readClientHello(opt.cipher_suites);
+        try h.readClientHello(opt.cipher_suites, opt.alpn_protocols);
         h.transcript.use(h.cipher_suite.hash());
     }
 
@@ -171,7 +177,19 @@ pub const Handshake = struct {
         try w.record(.change_cipher_spec, &[_]u8{1});
         {
             var hw = try w.writerAdvance(record.header_len);
-            try hw.handshakeRecord(.encrypted_extensions, &[_]u8{ 0, 0 });
+            if (h.alpn_protocol) |selected| {
+                // EncryptedExtensions with ALPN
+                // Build the extensions payload first
+                const proto_len: u16 = @intCast(selected.len);
+                const alpn_ext_len = 2 + 2 + 2 + 1 + proto_len; // ext_type(2) + ext_len(2) + list_len(2) + proto_len_byte(1) + proto
+                const ee_header_pos = try hw.skip(4); // handshake header placeholder
+                try hw.int(u16, alpn_ext_len); // extensions length
+                try hw.alpn(&.{selected});
+                var hdr_w = hw.writerAt(ee_header_pos);
+                try hdr_w.handshakeRecordHeader(.encrypted_extensions, hw.pos() - ee_header_pos - 4);
+            } else {
+                try hw.handshakeRecord(.encrypted_extensions, &[_]u8{ 0, 0 });
+            }
             h.transcript.update(hw.buffered());
             try h.writeEncrypted(&w, hw.buffered());
         }
@@ -361,7 +379,7 @@ pub const Handshake = struct {
         try hw.int(u16, ext_len); // extensions length
     }
 
-    fn readClientHello(h: *Self, supported_cipher_suites: []const CipherSuite) !void {
+    fn readClientHello(h: *Self, supported_cipher_suites: []const CipherSuite, server_alpn_protocols: []const []const u8) !void {
         var d = try Record.decoder(h.input);
         if (d.payload.len > max_cleartext_len) return error.TlsRecordOverflow;
         try d.expectContentType(.handshake);
@@ -465,6 +483,35 @@ pub const Handshake = struct {
                         if (!found) return error.TlsHandshakeFailure;
                     }
                 },
+                .application_layer_protocol_negotiation => {
+                    // RFC 7301: parse client ALPN extension and select a protocol
+                    if (server_alpn_protocols.len > 0) {
+                        const list_end = try d.decode(u16) + d.idx;
+                        // Find the first server protocol that the client supports
+                        // (server preference order)
+                        var best_match: ?[]const u8 = null;
+                        var best_server_idx: usize = server_alpn_protocols.len;
+                        const saved_idx = d.idx;
+                        for (server_alpn_protocols, 0..) |server_proto, si| {
+                            d.idx = saved_idx;
+                            while (d.idx < list_end) {
+                                const proto_len = try d.decode(u8);
+                                const client_proto = try d.slice(proto_len);
+                                if (si < best_server_idx and mem.eql(u8, client_proto, server_proto)) {
+                                    best_match = server_proto;
+                                    best_server_idx = si;
+                                }
+                            }
+                        }
+                        d.idx = list_end;
+                        h.alpn_protocol = best_match;
+                        if (best_match == null) {
+                            return error.TlsNoApplicationProtocol;
+                        }
+                    } else {
+                        try d.skip(extension_len);
+                    }
+                },
                 else => {
                     try d.skip(extension_len);
                 },
@@ -486,7 +533,7 @@ test "read client hello" {
         .output = undefined,
     };
     h.signature_scheme = .ecdsa_secp521r1_sha512; // this must be supported in signature_algorithms extension
-    try h.readClientHello(cipher_suites.tls13);
+    try h.readClientHello(cipher_suites.tls13, &.{});
 
     try testing.expectEqual(CipherSuite.AES_256_GCM_SHA384, h.cipher_suite);
     try testing.expectEqual(.x25519, h.named_group);
@@ -661,5 +708,10 @@ pub const NonBlock = struct {
     /// Cipher produced in handshake, null until successful handshake.
     pub fn cipher(self: Self) ?Cipher {
         return if (self.done()) self.inner.cipher else null;
+    }
+
+    /// ALPN protocol negotiated during handshake, null if none.
+    pub fn alpnProtocol(self: Self) ?[]const u8 {
+        return self.inner.alpn_protocol;
     }
 };

--- a/src/record.zig
+++ b/src/record.zig
@@ -336,6 +336,22 @@ pub const Writer = struct {
         try w.inner.writeAll(host);
     }
 
+    /// ALPN extension (RFC 7301)
+    pub fn alpn(w: *Writer, protocols: []const []const u8) !void {
+        // Calculate total length of the protocol name list
+        var list_len: u16 = 0;
+        for (protocols) |p| {
+            list_len += @as(u16, @intCast(p.len)) + 1; // 1 byte length prefix per protocol
+        }
+        try w.enumValue(proto.Extension.application_layer_protocol_negotiation);
+        try w.int(u16, list_len + 2); // extension data length
+        try w.int(u16, list_len); // protocol name list length
+        for (protocols) |p| {
+            try w.int(u8, p.len);
+            try w.slice(p);
+        }
+    }
+
     /// Writes header of the pre shared key extension, without binders
     pub fn preSharedKey(
         w: *Writer,

--- a/src/root.zig
+++ b/src/root.zig
@@ -40,6 +40,7 @@ pub fn client(input: *Io.Reader, output: *Io.Writer, opt: config.Client) !Connec
         .output = output,
         .session_resumption_secret_idx = session_resumption_secret_idx,
         .session_resumption = opt.session_resumption,
+        .alpn_protocol = hc.alpn_protocol,
     };
 }
 
@@ -56,6 +57,7 @@ pub fn server(input: *Io.Reader, output: *Io.Writer, opt: config.Server) !Connec
         .cipher = cipher,
         .input = input,
         .output = output,
+        .alpn_protocol = hs.alpn_protocol,
     };
 }
 
@@ -198,6 +200,143 @@ test "nonblock handshake and connection" {
             try testing.expect(d.closed);
         }
     }
+}
+
+test "ALPN negotiation: h2 selected" {
+    const testing = @import("std").testing;
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const rng = rng_impl.interface();
+
+    var sc_buf: [max_ciphertext_record_len]u8 = undefined;
+    var cs_buf: [max_ciphertext_record_len]u8 = undefined;
+
+    var cli = nonblock.Client.init(.{
+        .rng = rng,
+        .root_ca = .{},
+        .host = &.{},
+        .insecure_skip_verify = true,
+        .now = .zero,
+        .alpn_protocols = &.{ "h2", "http/1.1" },
+    });
+    var srv = nonblock.Server.init(.{
+        .rng = rng,
+        .auth = null,
+        .now = .zero,
+        .alpn_protocols = &.{ "h2", "http/1.1" },
+    });
+
+    // client flight 1
+    var cr = try cli.run(&sc_buf, &cs_buf);
+    // server flight 1
+    var sr = try srv.run(cs_buf[0..cr.send_pos], &sc_buf);
+    // client flight 2
+    cr = try cli.run(sc_buf[0..sr.send_pos], &cs_buf);
+    try testing.expect(cli.done());
+    // server parses client finished
+    sr = try srv.run(cs_buf[0..cr.send_pos], &sc_buf);
+    try testing.expect(srv.done());
+
+    // Both sides should have negotiated "h2"
+    try testing.expectEqualStrings("h2", cli.alpnProtocol().?);
+    try testing.expectEqualStrings("h2", srv.alpnProtocol().?);
+}
+
+test "ALPN negotiation: server picks preferred protocol" {
+    const testing = @import("std").testing;
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const rng = rng_impl.interface();
+
+    var sc_buf: [max_ciphertext_record_len]u8 = undefined;
+    var cs_buf: [max_ciphertext_record_len]u8 = undefined;
+
+    // Client offers http/1.1 and h2; server only supports http/1.1
+    var cli = nonblock.Client.init(.{
+        .rng = rng,
+        .root_ca = .{},
+        .host = &.{},
+        .insecure_skip_verify = true,
+        .now = .zero,
+        .alpn_protocols = &.{ "h2", "http/1.1" },
+    });
+    var srv = nonblock.Server.init(.{
+        .rng = rng,
+        .auth = null,
+        .now = .zero,
+        .alpn_protocols = &.{"http/1.1"},
+    });
+
+    var cr = try cli.run(&sc_buf, &cs_buf);
+    var sr = try srv.run(cs_buf[0..cr.send_pos], &sc_buf);
+    cr = try cli.run(sc_buf[0..sr.send_pos], &cs_buf);
+    try testing.expect(cli.done());
+    sr = try srv.run(cs_buf[0..cr.send_pos], &sc_buf);
+    try testing.expect(srv.done());
+
+    try testing.expectEqualStrings("http/1.1", cli.alpnProtocol().?);
+    try testing.expectEqualStrings("http/1.1", srv.alpnProtocol().?);
+}
+
+test "ALPN negotiation: no ALPN when not configured" {
+    const testing = @import("std").testing;
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const rng = rng_impl.interface();
+
+    var sc_buf: [max_ciphertext_record_len]u8 = undefined;
+    var cs_buf: [max_ciphertext_record_len]u8 = undefined;
+
+    // Neither side configures ALPN
+    var cli = nonblock.Client.init(.{
+        .rng = rng,
+        .root_ca = .{},
+        .host = &.{},
+        .insecure_skip_verify = true,
+        .now = .zero,
+    });
+    var srv = nonblock.Server.init(.{
+        .rng = rng,
+        .auth = null,
+        .now = .zero,
+    });
+
+    var cr = try cli.run(&sc_buf, &cs_buf);
+    var sr = try srv.run(cs_buf[0..cr.send_pos], &sc_buf);
+    cr = try cli.run(sc_buf[0..sr.send_pos], &cs_buf);
+    try testing.expect(cli.done());
+    sr = try srv.run(cs_buf[0..cr.send_pos], &sc_buf);
+    try testing.expect(srv.done());
+
+    // No ALPN negotiated
+    try testing.expectEqual(@as(?[]const u8, null), cli.alpnProtocol());
+    try testing.expectEqual(@as(?[]const u8, null), srv.alpnProtocol());
+}
+
+test "ALPN negotiation: no common protocol is error" {
+    const testing = @import("std").testing;
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const rng = rng_impl.interface();
+
+    var sc_buf: [max_ciphertext_record_len]u8 = undefined;
+    var cs_buf: [max_ciphertext_record_len]u8 = undefined;
+
+    // Client only offers h2, server only supports http/1.1
+    var cli = nonblock.Client.init(.{
+        .rng = rng,
+        .root_ca = .{},
+        .host = &.{},
+        .insecure_skip_verify = true,
+        .now = .zero,
+        .alpn_protocols = &.{"h2"},
+    });
+    var srv = nonblock.Server.init(.{
+        .rng = rng,
+        .auth = null,
+        .now = .zero,
+        .alpn_protocols = &.{"http/1.1"},
+    });
+
+    var cr = try cli.run(&sc_buf, &cs_buf);
+    // Server should reject with no_application_protocol
+    try testing.expectError(error.TlsNoApplicationProtocol, srv.run(cs_buf[0..cr.send_pos], &sc_buf));
 }
 
 test {


### PR DESCRIPTION
  Implement RFC 7301 ALPN extension for both client and server handshakes,
  enabling protocol negotiation (e.g., h2, http/1.1) during the TLS
  handshake. The server uses server-preference ordering when selecting a
  protocol and returns TlsNoApplicationProtocol when no common protocol
  exists. The negotiated protocol is exposed on the Connection object via
  the alpn_protocol field.
 