### PR TITLE
Writer.drain: coalesce 1-byte splat through a stack buffer

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -314,9 +314,23 @@ pub const Connection = struct {
             // Last element of `data` is repeated as necessary so that it is
             // written `splat` number of times, which may be zero.
             const pattern = data[data.len - 1];
-            for (0..splat) |_| {
-                try self.writeAll(pattern);
-                n += pattern.len;
+            switch (pattern.len) {
+                0 => {},
+                1 => {
+                    var buffer: [cipher.max_cleartext_len]u8 = undefined;
+                    @memset(&buffer, pattern[0]);
+                    var remaining = splat;
+                    while (remaining > 0) {
+                        const chunk_len = @min(remaining, buffer.len);
+                        try self.writeAll(buffer[0..chunk_len]);
+                        remaining -= chunk_len;
+                    }
+                    n += splat;
+                },
+                else => for (0..splat) |_| {
+                    try self.writeAll(pattern);
+                    n += pattern.len;
+                },
             }
 
             // Number of bytes consumed from `data` is returned, excluding bytes


### PR DESCRIPTION
Each call to Connection.writeAll emits a fresh TLS record (header + AEAD nonce + auth tag), so the previous loop (one writeAll per splat repetition) produced one record per byte for the common 1-byte pattern case. A 1 MiB splat became one million tiny records which is roughly three orders of magnitude slower than necessary.

This change switches on pattern.len to handle the 1-byte case which mirrors std.Io.Writer's Hashing and Allocating drains.