### PR TITLE
Very small patch to fix compile error

### DIFF
--- a/src/record.zig
+++ b/src/record.zig
@@ -110,7 +110,7 @@ pub const Decoder = struct {
             },
             .@"enum" => |info| {
                 const int = try d.decode(info.tag_type);
-                if (info.mode == .exhaustive) @compileError("exhaustive enum cannot be used");
+                if (info.is_exhaustive) @compileError("exhaustive enum cannot be used");
                 return @as(T, @enumFromInt(int));
             },
             else => @compileError("unsupported type: " ++ @typeName(T)),


### PR DESCRIPTION
It looks like a check in `record.zig` was accessing a deprecated field of enum info, which would cause a build error when enum was in use