### PR TITLE
Fix dangling `alpn_protocol` slice

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -57,7 +57,7 @@ pub fn server(input: *Io.Reader, output: *Io.Writer, opt: config.Server) !Connec
         .cipher = cipher,
         .input = input,
         .output = output,
-        .alpn_protocol = findAlpnProtocol(opt.alpn_protocols, hs.alpn_protocol),
+        .alpn_protocol = hs.alpn_protocol,
     };
 }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -40,7 +40,7 @@ pub fn client(input: *Io.Reader, output: *Io.Writer, opt: config.Client) !Connec
         .output = output,
         .session_resumption_secret_idx = session_resumption_secret_idx,
         .session_resumption = opt.session_resumption,
-        .alpn_protocol = hc.alpn_protocol,
+        .alpn_protocol = findAlpnProtocol(opt.alpn_protocols, hc.alpn_protocol),
     };
 }
 
@@ -57,8 +57,18 @@ pub fn server(input: *Io.Reader, output: *Io.Writer, opt: config.Server) !Connec
         .cipher = cipher,
         .input = input,
         .output = output,
-        .alpn_protocol = hs.alpn_protocol,
+        .alpn_protocol = findAlpnProtocol(opt.alpn_protocols, hs.alpn_protocol),
     };
+}
+
+fn findAlpnProtocol(protocols: []const []const u8, selected: ?[]const u8) ?[]const u8 {
+    if (selected) |sel| {
+        for (protocols) |proto| {
+            if (std.mem.eql(u8, proto, sel)) return proto;
+        }
+        // if we got a protocol that is not in the list, that's a violation of RFC 7301
+    }
+    return null;
 }
 
 /// With default buffer sizes


### PR DESCRIPTION
The `alpn_protocol` slice points to client/server handshake struct, which only lives temporarily inside `client()` or `server()` functions. Once they exit, the slice becomes invalid as the stack space will be reused.