### PR TITLE
Don't widen reader/writer err field to anyerror

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -239,7 +239,9 @@ pub const Connection = struct {
     pub const Reader = struct {
         conn: *Connection,
         interface: Io.Reader,
-        err: ?anyerror = null,
+        err: ?Error = null,
+
+        pub const Error = @typeInfo(@typeInfo(@TypeOf(Connection.read)).@"fn".return_type.?).error_union.error_set;
 
         pub fn init(c: *Connection, buffer: []u8) Reader {
             return .{
@@ -282,7 +284,9 @@ pub const Connection = struct {
     pub const Writer = struct {
         conn: *Connection,
         interface: Io.Writer,
-        err: ?anyerror = null,
+        err: ?Error = null,
+
+        pub const Error = @typeInfo(@typeInfo(@TypeOf(Connection.writeAll)).@"fn".return_type.?).error_union.error_set;
 
         pub fn init(c: *Connection, buffer: []u8) Writer {
             return .{


### PR DESCRIPTION
It's hard to work with `anyerror`, and it doesn't have to be that wide.