### PR TITLE
Add TLS 1.2 extended master secret support

### DIFF
--- a/src/handshake_client.zig
+++ b/src/handshake_client.zig
@@ -238,6 +238,8 @@ pub const Handshake = struct {
     /// ALPN protocol selected by the server, copied into alpn_protocol_buf.
     alpn_protocol: ?[]const u8 = null,
     alpn_protocol_buf: [32]u8 = undefined,
+    extended_master_secret_advertised: bool = false,
+    extended_master_secret_negotiated: bool = false,
     // statistics
     max_server_record_len: usize = 0,
     max_server_cleartext_len: usize = 0,
@@ -358,8 +360,7 @@ pub const Handshake = struct {
         }
 
         // tls 1.2 specific handshake part
-        try h.generateCipher(opt.key_log_callback, opt.rng);
-        try h.makeClientFlight2Tls12(opt.auth, opt.rng); // client flight 2
+        try h.makeClientFlight2Tls12(opt.auth, opt.rng, opt.key_log_callback); // client flight 2
         h.max_client_record_len = @max(h.max_client_record_len, h.output.end);
         try h.output.flush();
         try h.readServerFlight2(); // server flight 2
@@ -386,8 +387,7 @@ pub const Handshake = struct {
             h.cipher = app_cipher;
         } else {
             // tls 1.2 specific handshake part
-            try h.generateCipher(opt.key_log_callback, opt.rng);
-            try h.makeClientFlight2Tls12(opt.auth, opt.rng);
+            try h.makeClientFlight2Tls12(opt.auth, opt.rng, opt.key_log_callback);
         }
     }
 
@@ -398,7 +398,6 @@ pub const Handshake = struct {
 
     /// Prepare key material and generate cipher for TLS 1.2
     fn generateCipher(h: *Self, key_log_callback: ?key_log.Callback, rng: std.Random) !void {
-        try h.verifyCertificateSignatureTls12();
         try h.generateKeyMaterial(key_log_callback);
         h.cipher = try Cipher.initTls12(h.cipher_suite, &h.key_material, .client, rng);
     }
@@ -410,7 +409,11 @@ pub const Handshake = struct {
         else
             &h.rsa_secret.secret;
 
-        h.transcript.masterSecret(&h.master_secret, pre_master_secret, h.client_random, h.server_random);
+        if (h.extended_master_secret_negotiated) {
+            h.transcript.extendedMasterSecret(&h.master_secret, pre_master_secret);
+        } else {
+            h.transcript.masterSecret(&h.master_secret, pre_master_secret, h.client_random, h.server_random);
+        }
         h.transcript.keyMaterial(&h.key_material, &h.master_secret, h.client_random, h.server_random);
 
         if (key_log_callback) |cb| {
@@ -440,6 +443,9 @@ pub const Handshake = struct {
     }
 
     fn makeClientHello(h: *Self, opt: Options, resumption_ticket: ?ResumptionTicket) !void {
+        h.extended_master_secret_advertised = false;
+        h.extended_master_secret_negotiated = false;
+
         // Prepare data
         const tls_versions = try CipherSuite.versions(opt.cipher_suites);
         const shared_keys: []const []const u8 = if (tls_versions != .tls_1_2) brk: {
@@ -476,6 +482,11 @@ pub const Handshake = struct {
         try w.serverName(opt.host);
         if (opt.alpn_protocols.len > 0) {
             try w.alpn(opt.alpn_protocols);
+        }
+        if (tls_versions != .tls_1_3) {
+            try w.enumValue(proto.Extension.extended_master_secret);
+            try w.int(u16, 0);
+            h.extended_master_secret_advertised = true;
         }
         // binder key placeholder
         const binder_pos: ?usize = if (resumption_ticket) |ticket| brk: {
@@ -576,6 +587,7 @@ pub const Handshake = struct {
 
     /// Parse server hello message.
     fn parseServerHello(h: *Self, d: *record.Decoder, length: u24) !void {
+        h.extended_master_secret_negotiated = false;
         if (try d.decode(proto.Version) != proto.Version.tls_1_2)
             return error.TlsBadVersion;
         h.server_random = try d.array(32);
@@ -625,12 +637,19 @@ pub const Handshake = struct {
                     .pre_shared_key => {
                         h.pre_shared_selected_identity = try d.decode(u16);
                     },
+                    .extended_master_secret => {
+                        if (len != 0) return error.TlsIllegalParameter;
+                        if (!h.extended_master_secret_advertised) return error.TlsUnsupportedExtension;
+                        h.extended_master_secret_negotiated = true;
+                    },
                     else => {
                         try d.skip(len);
                     },
                 }
             }
         }
+        if (h.extended_master_secret_negotiated and h.tls_version != .tls_1_2)
+            return error.TlsUnsupportedExtension;
     }
 
     fn isServerHelloRetryRequest(server_random: []const u8) bool {
@@ -784,7 +803,14 @@ pub const Handshake = struct {
     /// finished messages for tls 1.2.
     /// If client certificate is requested also adds client certificate and
     /// certificate verify messages.
-    fn makeClientFlight2Tls12(h: *Self, auth: ?*CertKeyPair, rng: std.Random) !void {
+    fn makeClientFlight2Tls12(
+        h: *Self,
+        auth: ?*CertKeyPair,
+        rng: std.Random,
+        key_log_callback: ?key_log.Callback,
+    ) !void {
+        try h.verifyCertificateSignatureTls12();
+
         var w: record.Writer = .initFromIo(h.output);
         var cert_builder: ?CertificateBuilder = null;
 
@@ -822,6 +848,8 @@ pub const Handshake = struct {
             h.transcript.update(hw.buffered());
             try w.record(.handshake, hw.buffered());
         }
+
+        try h.generateCipher(key_log_callback, rng);
 
         // Client certificate verify
         if (cert_builder) |cb| {
@@ -975,6 +1003,19 @@ const data12 = @import("testdata/tls12.zig");
 const data13 = @import("testdata/tls13.zig");
 const testu = @import("testu.zig");
 
+fn serverHelloWithExtraExtension(comptime extension_hex: []const u8) [data12.server_hello.len + testu.hexToBytes(extension_hex).len]u8 {
+    const extension = testu.hexToBytes(extension_hex);
+    var server_hello: [data12.server_hello.len + extension.len]u8 = undefined;
+
+    @memcpy(server_hello[0..data12.server_hello.len], &data12.server_hello);
+    @memcpy(server_hello[data12.server_hello.len..], &extension);
+    std.mem.writeInt(u16, server_hello[3..5], std.mem.readInt(u16, data12.server_hello[3..5], .big) + extension.len, .big);
+    std.mem.writeInt(u24, server_hello[6..9], std.mem.readInt(u24, data12.server_hello[6..9], .big) + extension.len, .big);
+    std.mem.writeInt(u16, server_hello[47..49], std.mem.readInt(u16, data12.server_hello[47..49], .big) + extension.len, .big);
+
+    return server_hello;
+}
+
 test "parse tls 1.2 server hello" {
     var buffer: [1024]u8 = undefined;
     var writer: Io.Writer = .fixed(&buffer);
@@ -1005,6 +1046,118 @@ test "parse tls 1.2 server hello" {
     try h.generateKeyMaterial(null);
 
     try testing.expectEqualSlices(u8, &data12.key_material, h.key_material[0..data12.key_material.len]);
+}
+
+test "parse tls 1.2 server hello negotiates extended master secret" {
+    const server_hello = serverHelloWithExtraExtension("00 17 00 00");
+    var reader: Io.Reader = .fixed(&server_hello);
+    var d = try Record.decoder(&reader);
+
+    try testing.expectEqual(.server_hello, try d.decode(proto.Handshake));
+    const length = try d.decode(u24);
+
+    var h: Handshake = .{
+        .output = undefined,
+        .input = undefined,
+        .extended_master_secret_advertised = true,
+    };
+    try h.parseServerHello(&d, length);
+
+    try testing.expect(h.extended_master_secret_negotiated);
+    try testing.expectEqual(.tls_1_2, h.tls_version);
+}
+
+test "parse tls 1.2 server hello rejects malformed extended master secret" {
+    const server_hello = serverHelloWithExtraExtension("00 17 00 01 00");
+    var reader: Io.Reader = .fixed(&server_hello);
+    var d = try Record.decoder(&reader);
+
+    try testing.expectEqual(.server_hello, try d.decode(proto.Handshake));
+    const length = try d.decode(u24);
+
+    var h: Handshake = .{
+        .output = undefined,
+        .input = undefined,
+        .extended_master_secret_advertised = true,
+    };
+    try testing.expectError(error.TlsIllegalParameter, h.parseServerHello(&d, length));
+}
+
+test "parse tls 1.2 server hello rejects unsolicited extended master secret" {
+    const server_hello = serverHelloWithExtraExtension("00 17 00 00");
+    var reader: Io.Reader = .fixed(&server_hello);
+    var d = try Record.decoder(&reader);
+
+    try testing.expectEqual(.server_hello, try d.decode(proto.Handshake));
+    const length = try d.decode(u24);
+
+    var h: Handshake = .{ .output = undefined, .input = undefined };
+    try testing.expectError(error.TlsUnsupportedExtension, h.parseServerHello(&d, length));
+}
+
+test "tls 1.2 extended master secret uses session hash" {
+    const expected_master_secret = testu.hexToBytes(
+        \\ 96 01 43 e1 bc 08 95 e7 2b 36 0f 49 c9 11 32 e4
+        \\ 40 b1 e3 05 9e 6d f2 dd 89 4f fc 61 66 d7 67 c6
+        \\ 32 9b f5 b7 6d 38 3a 24 95 5d bf 03 81 78 e4 b0
+    );
+
+    var h: Handshake = .{
+        .output = undefined,
+        .input = undefined,
+        .client_random = data12.client_random,
+        .server_random = data12.server_random,
+        .cipher_suite = .ECDHE_RSA_WITH_AES_128_CBC_SHA,
+        .named_group = .x25519,
+        .server_pub_key = &data12.server_pub_key,
+        .extended_master_secret_negotiated = true,
+    };
+    h.dh_kp.x25519_kp.secret_key = data12.client_secret;
+    h.transcript.use(h.cipher_suite.hash());
+
+    for (data12.handshake_messages) |msg| {
+        h.transcript.update(msg[record.header_len..]);
+    }
+
+    try h.generateKeyMaterial(null);
+    try testing.expectEqualSlices(u8, &expected_master_secret, &h.master_secret);
+    try testing.expect(!mem.eql(u8, &data12.master_secret, &h.master_secret));
+}
+
+test "tls 1.2 client flight derives extended master secret after client key exchange" {
+    const expected_master_secret = testu.hexToBytes(
+        \\ cf 5f e6 38 4b fb d9 6f 5b 9e f1 18 27 1a 93 2a
+        \\ 86 f9 d1 49 7f ce 31 25 b8 aa e0 2c e2 99 76 44
+        \\ 1d 80 b1 31 b2 f4 f0 bf 19 69 2a 83 f5 ab 28 6b
+    );
+    const server_hello = serverHelloWithExtraExtension("00 17 00 00");
+    const server_hello_responses = server_hello ++
+        data12.server_certificate ++ data12.server_key_exchange ++ data12.server_hello_done;
+
+    var buffer: [1024]u8 = undefined;
+    var writer: Io.Writer = .fixed(&buffer);
+    var reader: Io.Reader = .fixed(&server_hello_responses);
+    var h: Handshake = .{
+        .output = &writer,
+        .input = &reader,
+        .client_random = data12.client_random,
+        .extended_master_secret_advertised = true,
+    };
+    h.dh_kp.x25519_kp = .{
+        .secret_key = data12.client_secret,
+        .public_key = data12.client_key_exchange_for_transcript[record.header_len + 5 ..][0..32].*,
+    };
+    h.cert = .{ .host = "example.ulfheim.net", .skip_verify = true, .root_ca = .empty, .now_sec = 0 };
+    h.transcript.update(data12.client_hello[record.header_len..]);
+
+    try h.readServerFlight1();
+    h.transcript.use(h.cipher_suite.hash());
+    try testing.expect(h.extended_master_secret_negotiated);
+
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    try h.makeClientFlight2Tls12(null, rng_impl.interface(), null);
+
+    try testing.expectEqualSlices(u8, &expected_master_secret, &h.master_secret);
 }
 
 test "verify google.com certificate" {
@@ -1150,18 +1303,19 @@ test "tls 1.3 process server flight" {
 
 test "create client hello" {
     const expected = testu.hexToBytes(
-        "16 03 03 00 6d " ++ // record header
-            "01 00 00 69 " ++ // handshake header
+        "16 03 03 00 71 " ++ // record header
+            "01 00 00 6d " ++ // handshake header
             "03 03 " ++ // protocol version
             "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f " ++ // client random
             "00 " ++ // no session id
             "00 02 c0 2b " ++ // cipher suites
             "01 00 " ++ // compression methods
-            "00 3e " ++ // extensions length
+            "00 42 " ++ // extensions length
             "00 2b 00 03 02 03 03 " ++ // supported versions extension
             "00 0d 00 14 00 12 04 03 05 03 08 04 08 05 08 06 08 07 02 01 04 01 05 01 " ++ // signature algorithms extension
             "00 0a 00 08 00 06 00 1d 00 17 00 18 " ++ // named groups extension
-            "00 00 00 0f 00 0d 00 00 0a 67 6f 6f 67 6c 65 2e 63 6f 6d ", // server name extension
+            "00 00 00 0f 00 0d 00 00 0a 67 6f 6f 67 6c 65 2e 63 6f 6d " ++ // server name extension
+            "00 17 00 00 ", // extended master secret extension
     );
 
     var h = brk: {
@@ -1188,8 +1342,60 @@ test "create client hello" {
 
     const actual = h.output.buffered();
     try testing.expectEqualSlices(u8, &expected, actual);
-    try testing.expectEqual(152, h.output.unusedCapacityLen());
-    try testing.expectEqual(114, expected.len);
+    try testing.expect(h.extended_master_secret_advertised);
+    try testing.expectEqual(148, h.output.unusedCapacityLen());
+    try testing.expectEqual(118, expected.len);
+}
+
+test "client hello advertises extended master secret when TLS 1.2 is offered" {
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const opt: Options = .{
+        .rng = rng_impl.interface(),
+        .host = "google.com",
+        .root_ca = .empty,
+        .cipher_suites = &.{
+            .AES_256_GCM_SHA384,
+            .ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        },
+        .named_groups = &.{.x25519},
+        .now = .zero,
+    };
+
+    var buffer: [1024]u8 = undefined;
+    var writer: Io.Writer = .fixed(&buffer);
+    var h: Handshake = .{ .output = &writer, .input = undefined };
+    try h.initKeys(opt);
+    try h.makeClientHello(opt, null);
+
+    const extension = testu.hexToBytes("00 17 00 00");
+    try testing.expect(mem.indexOf(u8, h.output.buffered(), &extension) != null);
+    try testing.expect(h.extended_master_secret_advertised);
+}
+
+test "client hello omits extended master secret for TLS 1.3 only" {
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const opt: Options = .{
+        .rng = rng_impl.interface(),
+        .host = "google.com",
+        .root_ca = .empty,
+        .cipher_suites = &.{.AES_256_GCM_SHA384},
+        .named_groups = &.{.x25519},
+        .now = .zero,
+    };
+
+    var buffer: [1024]u8 = undefined;
+    var writer: Io.Writer = .fixed(&buffer);
+    var h: Handshake = .{
+        .output = &writer,
+        .input = undefined,
+        .extended_master_secret_advertised = true,
+    };
+    try h.initKeys(opt);
+    try h.makeClientHello(opt, null);
+
+    const extension = testu.hexToBytes("00 17 00 00");
+    try testing.expect(mem.indexOf(u8, h.output.buffered(), &extension) == null);
+    try testing.expect(!h.extended_master_secret_advertised);
 }
 
 test "client hello size" {
@@ -1211,7 +1417,7 @@ test "client hello size" {
     };
     try h.initKeys(opt);
     try h.makeClientHello(opt, null);
-    try testing.expectEqual(1572 + opt.host.len, h.output.end);
+    try testing.expectEqual(1576 + opt.host.len, h.output.end);
     //try testing.expectEqual(2794 + opt.host.len, h.stream_writer.end);
 }
 

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -66,6 +66,8 @@ pub const Extension = enum(u16) {
     server_certificate_type = 20,
     /// RFC 7685
     padding = 21,
+    /// RFC 7627
+    extended_master_secret = 23,
     /// RFC 8446
     pre_shared_key = 41,
     /// RFC 8446

--- a/src/transcript.zig
+++ b/src/transcript.zig
@@ -67,6 +67,19 @@ pub const Transcript = struct {
         }
     }
 
+    pub fn extendedMasterSecret(
+        t: *Transcript,
+        out: []u8,
+        pre_master_secret: []const u8,
+    ) void {
+        switch (t.tag) {
+            inline else => |h| @field(t, @tagName(h)).extendedMasterSecret(
+                out,
+                pre_master_secret,
+            ),
+        }
+    }
+
     pub fn keyMaterial(
         t: *Transcript,
         out: []u8,
@@ -233,6 +246,28 @@ fn TranscriptT(comptime Hash: type) type {
             server_random: [32]u8,
         ) void {
             const seed = "master secret" ++ client_random ++ server_random;
+
+            var a1: [hash_length]u8 = undefined;
+            var a2: [hash_length]u8 = undefined;
+            Hmac.create(&a1, seed, pre_master_secret);
+            Hmac.create(&a2, &a1, pre_master_secret);
+
+            var p1: [hash_length]u8 = undefined;
+            var p2: [hash_length]u8 = undefined;
+            Hmac.create(&p1, a1 ++ seed, pre_master_secret);
+            Hmac.create(&p2, a2 ++ seed, pre_master_secret);
+
+            const master_secret = p1 ++ p2;
+            const len = @min(out.len, master_secret.len);
+            @memcpy(out[0..len], master_secret[0..len]);
+        }
+
+        fn extendedMasterSecret(
+            self: *Self,
+            out: []u8,
+            pre_master_secret: []const u8,
+        ) void {
+            const seed = "extended master secret" ++ self.hash.peek();
 
             var a1: [hash_length]u8 = undefined;
             var a2: [hash_length]u8 = undefined;


### PR DESCRIPTION
## Overview

This adds TLS 1.2 Extended Master Secret (EMS) negotiation and key derivation. When the server selects EMS, the client derives the master secret from the handshake session hash instead of only the client and server random values.

This pull request was generated by GitHub Copilot at @cataggar's direction.

## Details

[RFC 7627](https://datatracker.ietf.org/doc/html/rfc7627) binds the TLS master secret to the complete handshake that established it. This prevents different handshakes from producing connections with the same master secret, addressing the compound-authentication and triple-handshake weaknesses described in [RFC 7627 section 1](https://datatracker.ietf.org/doc/html/rfc7627#section-1).

The client now:

- Advertises extension type 23 (`extended_master_secret`) whenever TLS 1.2 is offered, including mixed TLS 1.3/TLS 1.2 ClientHellos, but omits it for TLS 1.3-only configurations.
- Accepts the extension only when it was advertised, requires its payload to be empty, and rejects it if the negotiated protocol is not TLS 1.2, following [RFC 7627 section 5.2](https://datatracker.ietf.org/doc/html/rfc7627#section-5.2).
- Computes `master_secret = PRF(pre_master_secret, "extended master secret", session_hash)[0..47]` when EMS is negotiated, as specified by [RFC 7627 section 4](https://datatracker.ietf.org/doc/html/rfc7627#section-4).
- Delays TLS 1.2 master-secret and cipher generation until immediately after ClientKeyExchange is added to the transcript. This ensures `session_hash` covers ClientHello through ClientKeyExchange, including a client Certificate when present, but not CertificateVerify.
- Preserves the existing RFC 5246 master-secret derivation when EMS is not negotiated.

Tests cover ClientHello advertisement and TLS 1.3-only omission, valid negotiation, malformed and unsolicited extensions, the RFC 7627 session-hash derivation, and the required derivation timing after ClientKeyExchange.

This is intentionally limited to EMS. Secure-renegotiation behavior and TLS 1.2 NewSessionTicket transcript handling from cataggar/tls.zig#12 are not included.