### PR TITLE
re-export tls.config.ClientAuth

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -99,6 +99,7 @@ pub const config = struct {
 
     pub const Client = @import("handshake_client.zig").Options;
     pub const Server = @import("handshake_server.zig").Options;
+    pub const ClientAuth = @import("handshake_server.zig").ClientAuth;
 };
 
 /// Non-blocking client/server handshake and connection. Handshake produces


### PR DESCRIPTION
Client certificate settings for the server handshake were reachable only by importing handshake_server.zig directly, unlike every other option type in the config namespace.