### PR TITLE
Fix panic on an empty write

### DIFF
--- a/src/cipher.zig
+++ b/src/cipher.zig
@@ -493,7 +493,7 @@ fn Aead13Type(comptime AeadType: type, comptime Hash: type) type {
             header.* = record.header(.application_data, payload_len);
 
             // Skip @memcpy if cleartext is already part of the buf at right position
-            if (&cleartext[0] != &buf[record.header_len]) {
+            if (cleartext.ptr != buf[record.header_len..].ptr) {
                 @memcpy(buf[record.header_len..][0..cleartext.len], cleartext);
             }
             buf[record.header_len + cleartext.len] = @intFromEnum(content_type);
@@ -1088,4 +1088,16 @@ test testCiphers {
         try testing.expectEqualStrings(close_notify, cleartext);
         try testing.expectEqual(.alert, content_type);
     }
+}
+
+test "encrypt a record with no cleartext" {
+    var client_cipher, var server_cipher = testCiphers();
+
+    var buf: [128]u8 = undefined;
+    const encrypted = try client_cipher.encrypt(&buf, .application_data, "");
+
+    var out: [128]u8 = undefined;
+    const content_type, const decrypted = try server_cipher.decrypt(&out, Record.init(encrypted));
+    try testing.expectEqual(.application_data, content_type);
+    try testing.expectEqualStrings("", decrypted);
 }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -159,6 +159,7 @@ pub const Connection = struct {
     /// tls record. Max single tls record payload length is 1<<14 (16K)
     /// bytes.
     pub fn write(c: *Self, bytes: []const u8) !usize {
+        if (bytes.len == 0) return 0;
         const encrypt_overhead = c.cipher.encryptOverhead();
         assert(c.output.buffer.len > encrypt_overhead);
         // Find maximum number of bytes which can fit into output buffer as encrypted ciphertext
@@ -691,4 +692,15 @@ test "nonblock decrypt" {
 
     const res = try conn.decrypt(&ciphertext, &cleartext_buf);
     try testing.expectEqualSlices(u8, "ping", res.cleartext);
+}
+
+test "write with nothing to write" {
+    const client_cipher, _ = cipher.testCiphers();
+    var output_buf: [256]u8 = undefined;
+    var output: Io.Writer = .fixed(&output_buf);
+    var input: Io.Reader = .fixed("");
+    var conn: Connection = .{ .input = &input, .output = &output, .cipher = client_cipher };
+
+    try testing.expectEqual(0, try conn.write(""));
+    try testing.expectEqual(0, output.buffered().len);
 }


### PR DESCRIPTION
- `write("")` now returns 0 without encoding anything, which is what `writeAll("")` already does (its loop never runs).

- `Cipher.encrypt` compares slice pointers instead of indexing. It is callable on its own and an empty record is legal, so it should encode one rather than crash.
