### PR TITLE
Run CI on the 0.16.x branch and stop announcing h2 support in ALPN

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push:
-    branches: [ "main", "zig-0.15.x" ]
+    branches: [ "main", "zig-0.15.x", "zig-0.16.x" ]
   pull_request:
 
 jobs:

--- a/example/http_get.zig
+++ b/example/http_get.zig
@@ -22,7 +22,7 @@ pub fn main(init: std.process.Init) !void {
             // to force cipher from specific tls version:
             //   .cipher_suites = tls.config.cipher_suites.tls12,
             .cipher_suites = tls.config.cipher_suites.secure,
-            .alpn_protocols = &.{ "http/1.1", "h2" },
+            .alpn_protocols = &.{"http/1.1"},
             .key_log_callback = tls.config.key_log.init(init.minimal.environ),
             .now = std.Io.Clock.real.now(io),
             .rng = rng_impl.interface(),

--- a/example/top_sites.zig
+++ b/example/top_sites.zig
@@ -68,7 +68,7 @@ pub fn run(gpa: std.mem.Allocator, io: Io, domain: []const u8, root_ca: tls.conf
         .diagnostic = &diagnostic,
         .now = std.Io.Clock.real.now(io),
         .rng = rng_impl.interface(),
-        .alpn_protocols = &.{ "http/1.1", "h2" },
+        .alpn_protocols = &.{"http/1.1"},
     };
     if (cmn.inList(domain, &cmn.no_keyber)) {
         opt.named_groups = &[_]tls.config.NamedGroup{ .x25519, .secp256r1 };


### PR DESCRIPTION
Run CI on the branch, and stop announcing h2 via ALPN in examples/tests, which don't really support it. The later change is a preparation for my error refactoring, which breaks many top sites, which behave differently in h2 mode, which the client can't handle.