### PR TITLE
Don't answer the peer's alert with an alert of our own

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -135,7 +135,8 @@ pub const Connection = struct {
                 },
                 .alert => {
                     if (cleartext.len < 2) return error.TlsUnexpectedMessage;
-                    try proto.Alert.parse(cleartext[0..2].*).toError();
+                    // Decide on the description alone; see `Alert.parse`.
+                    try proto.Alert.parse(cleartext[0..2].*).description.toError();
                     // server side clean shutdown
                     @atomicStore(bool, &c.received_close_notify, true, .monotonic);
                     return error.EndOfStream;

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const mem = std.mem;
 const Io = std.Io;
 const assert = std.debug.assert;
 
@@ -73,10 +72,10 @@ pub const Connection = struct {
     pub fn next(c: *Self) anyerror!?[]const u8 {
         return c.nextRecord(&.{}) catch |err| {
             if (err == error.EndOfStream) return null;
-            // Write alert on tls errors.
-            // Stream errors return to the caller.
-            if (mem.startsWith(u8, @errorName(err), "Tls"))
-                @atomicStore(proto.Alert, &c.close_alert, proto.Alert.fromError(err), .monotonic);
+            // Remember the alert for `close` to send, when the failure is
+            // ours to report at all.
+            if (proto.Alert.forLocalError(err)) |alert|
+                @atomicStore(proto.Alert, &c.close_alert, alert, .monotonic);
             return err;
         };
     }
@@ -185,8 +184,8 @@ pub const Connection = struct {
         if (c.cleartext_buf.len == 0) {
             const cleartext = c.nextRecord(buffer) catch |err| {
                 if (err == error.EndOfStream) return 0;
-                if (mem.startsWith(u8, @errorName(err), "Tls"))
-                    @atomicStore(proto.Alert, &c.close_alert, proto.Alert.fromError(err), .monotonic);
+                if (proto.Alert.forLocalError(err)) |alert|
+                    @atomicStore(proto.Alert, &c.close_alert, alert, .monotonic);
                 return err;
             };
             if (cleartext.ptr == buffer.ptr) {

--- a/src/handshake_server.zig
+++ b/src/handshake_server.zig
@@ -91,13 +91,20 @@ pub const Handshake = struct {
 
     const Self = @This();
 
+    /// Tells the peer why we are failing, when the failure is ours to report.
+    ///
+    /// Sending errors are propagated, not swallowed. Their real cause is
+    /// recorded on the caller's writer and can be `error.Canceled`; dropping
+    /// it would lose a cancellation. A dead transport also outranks the
+    /// protocol error it would have replaced, since the peer will never see
+    /// the alert anyway.
     fn writeAlert(h: *Self, cph: ?*Cipher, err: anyerror) !void {
+        const cleartext = proto.alertForLocalError(err) orelse return;
         if (cph) |c| {
-            const cleartext = proto.alertFromError(err);
             const ciphertext = try c.encrypt(h.output.unusedCapacitySlice(), .alert, &cleartext);
             h.output.advance(ciphertext.len);
         } else {
-            const alert = record.header(.alert, 2) ++ proto.alertFromError(err);
+            const alert = record.header(.alert, 2) ++ cleartext;
             try h.output.writeAll(&alert);
         }
         try h.output.flush();
@@ -119,10 +126,8 @@ pub const Handshake = struct {
         try h.output.flush();
 
         h.clientFlight2(opt) catch |err| {
-            // Alert received from client
-            if (!mem.startsWith(u8, @errorName(err), "TlsAlert")) {
-                try h.writeAlert(&h.cipher, err);
-            }
+            // writeAlert stays quiet when the client is the one that failed.
+            try h.writeAlert(&h.cipher, err);
             return err;
         };
         return h.cipher;

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -227,11 +227,20 @@ pub const Alert = enum(u8) {
         };
     }
 
-    pub fn parse(buf: [2]u8) Alert {
-        const level: Alert.Level = @enumFromInt(buf[0]);
-        const alert: Alert = @enumFromInt(buf[1]);
-        _ = level;
-        return alert;
+    pub const Parsed = struct {
+        level: Level,
+        description: Alert,
+    };
+
+    /// Callers deliberately decide on `description` alone. TLS 1.3 makes
+    /// severity implicit in the alert type and says `level` "can safely be
+    /// ignored" (RFC 8446 6), and treating a TLS 1.2 warning-level alert as
+    /// fatal is the safe reading. `level` is kept for diagnostics.
+    pub fn parse(buf: [2]u8) Parsed {
+        return .{
+            .level = @enumFromInt(buf[0]),
+            .description = @enumFromInt(buf[1]),
+        };
     }
 
     pub fn format(alert: Alert) [2]u8 {
@@ -314,3 +323,14 @@ pub const Side = enum {
     client,
     server,
 };
+
+const testing = @import("std").testing;
+
+test "Alert.parse keeps the level" {
+    const parsed = Alert.parse(.{
+        @intFromEnum(Alert.Level.warning),
+        @intFromEnum(Alert.close_notify),
+    });
+    try testing.expectEqual(Alert.Level.warning, parsed.level);
+    try testing.expectEqual(Alert.close_notify, parsed.description);
+}

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -90,8 +90,11 @@ pub const Extension = enum(u16) {
     _,
 };
 
-pub fn alertFromError(err: anyerror) [2]u8 {
-    return [2]u8{ @intFromEnum(Alert.Level.fatal), @intFromEnum(Alert.fromError(err)) };
+/// The fatal alert to send for a locally detected failure, or null when
+/// there is nothing to tell the peer about. See `Alert.forLocalError`.
+pub fn alertForLocalError(err: anyerror) ?[2]u8 {
+    const alert = Alert.forLocalError(err) orelse return null;
+    return [2]u8{ @intFromEnum(Alert.Level.fatal), @intFromEnum(alert) };
 }
 
 pub const Alert = enum(u8) {
@@ -192,8 +195,31 @@ pub const Alert = enum(u8) {
         };
     }
 
-    pub fn fromError(err: anyerror) Alert {
+    /// True for the errors produced by `toError`, i.e. an alert the peer sent
+    /// us. Derived from `Error` rather than from the error name, so it cannot
+    /// drift as that set changes.
+    pub fn isFromPeer(err: anyerror) bool {
+        inline for (@typeInfo(Error).error_set.?) |e| {
+            if (err == @field(anyerror, e.name)) return true;
+        }
+        return false;
+    }
+
+    /// The alert describing a failure we detected locally, or null when the
+    /// peer should not be sent one: it already told us about its own failure,
+    /// or the transport is gone and there is nothing to send on.
+    pub fn forLocalError(err: anyerror) ?Alert {
+        if (isFromPeer(err)) return null;
         return switch (err) {
+            // Transport or resource failures. Not protocol violations, and
+            // in most cases there is no longer a connection to send on.
+            error.ReadFailed,
+            error.WriteFailed,
+            error.EndOfStream,
+            error.Canceled,
+            error.OutOfMemory,
+            => null,
+
             error.TlsUnexpectedMessage => .unexpected_message,
             error.TlsBadRecordMac => .bad_record_mac,
             error.TlsRecordOverflow => .record_overflow,
@@ -207,12 +233,18 @@ pub const Alert = enum(u8) {
             error.IdentityElement,
             error.InvalidEncoding,
             error.TlsNoSupportedCiphers,
+            error.TlsBadSignatureScheme,
+            error.TlsUnknownSignatureScheme,
             => .illegal_parameter,
             error.TlsUnknownCa => .unknown_ca,
             error.TlsAccessDenied => .access_denied,
             error.TlsDecodeError => .decode_error,
-            error.TlsDecryptError => .decrypt_error,
-            error.TlsProtocolVersion => .protocol_version,
+            error.TlsDecryptError, error.TlsDecryptFailure => .decrypt_error,
+            error.TlsProtocolVersion, error.TlsBadVersion => .protocol_version,
+            // The peer offered nothing we can complete the handshake with.
+            error.TlsServerHelloRetryRequest => .handshake_failure,
+            // Our own limitation rather than anything the peer did wrong.
+            error.TlsUnsupportedFragmentedHandshakeMessage => .internal_error,
             error.TlsInsufficientSecurity => .insufficient_security,
             error.TlsInternalError => .internal_error,
             error.TlsInappropriateFallback => .inappropriate_fallback,
@@ -333,4 +365,54 @@ test "Alert.parse keeps the level" {
     });
     try testing.expectEqual(Alert.Level.warning, parsed.level);
     try testing.expectEqual(Alert.close_notify, parsed.description);
+}
+
+test "Alert.isFromPeer covers exactly the alerts we can receive" {
+    inline for (@typeInfo(Alert.Error).error_set.?) |e| {
+        const err = @field(anyerror, e.name);
+        try testing.expect(Alert.isFromPeer(err));
+        // An alert the peer sent is its failure to report, not ours.
+        try testing.expectEqual(@as(?Alert, null), Alert.forLocalError(err));
+    }
+    try testing.expect(!Alert.isFromPeer(error.TlsDecodeError));
+}
+
+test "Alert.forLocalError sends nothing for transport failures" {
+    for ([_]anyerror{
+        error.ReadFailed,
+        error.WriteFailed,
+        error.EndOfStream,
+        error.Canceled,
+        error.OutOfMemory,
+    }) |err| {
+        try testing.expectEqual(@as(?Alert, null), Alert.forLocalError(err));
+    }
+}
+
+test "Alert.forLocalError maps local failures to a matching alert" {
+    const cases = [_]struct { err: anyerror, alert: Alert }{
+        .{ .err = error.TlsBadVersion, .alert = .protocol_version },
+        .{ .err = error.TlsProtocolVersion, .alert = .protocol_version },
+        .{ .err = error.TlsDecryptFailure, .alert = .decrypt_error },
+        .{ .err = error.TlsDecryptError, .alert = .decrypt_error },
+        .{ .err = error.TlsBadSignatureScheme, .alert = .illegal_parameter },
+        .{ .err = error.TlsUnknownSignatureScheme, .alert = .illegal_parameter },
+        .{ .err = error.TlsServerHelloRetryRequest, .alert = .handshake_failure },
+        .{ .err = error.TlsUnsupportedFragmentedHandshakeMessage, .alert = .internal_error },
+        .{ .err = error.TlsBadRecordMac, .alert = .bad_record_mac },
+        .{ .err = error.TlsNoApplicationProtocol, .alert = .no_application_protocol },
+    };
+    for (cases) |c| {
+        try testing.expectEqual(@as(?Alert, c.alert), Alert.forLocalError(c.err));
+    }
+    // Anything we did not classify is still reported, as internal_error.
+    try testing.expectEqual(@as(?Alert, .internal_error), Alert.forLocalError(error.Unexpected));
+}
+
+test "alertForLocalError builds a fatal record body, or none" {
+    try testing.expectEqualSlices(u8, &.{
+        @intFromEnum(Alert.Level.fatal),
+        @intFromEnum(Alert.protocol_version),
+    }, &(alertForLocalError(error.TlsBadVersion).?));
+    try testing.expectEqual(@as(?[2]u8, null), alertForLocalError(error.TlsAlertHandshakeFailure));
 }

--- a/src/record.zig
+++ b/src/record.zig
@@ -151,8 +151,13 @@ pub const Decoder = struct {
 
     pub fn raiseAlert(d: *Decoder) !void {
         if (d.payload.len < 2) return error.TlsUnexpectedMessage;
-        try proto.Alert.parse(try d.array(2)).toError();
-        return error.TlsAlertCloseNotify;
+        const alert = proto.Alert.parse(try d.array(2));
+        try alert.description.toError();
+        // toError only succeeds for the two alerts that are not failures.
+        return switch (alert.description) {
+            .user_canceled => error.TlsAlertUserCanceled,
+            else => error.TlsAlertCloseNotify,
+        };
     }
 };
 
@@ -475,4 +480,20 @@ pub fn handshakeHeader(handshake_type: proto.Handshake, payload_len: usize) [4]u
     ret[0] = @intFromEnum(handshake_type);
     std.mem.writeInt(u24, ret[1..4], @intCast(payload_len), .big);
     return ret;
+}
+
+test "raiseAlert distinguishes the alerts that are not failures" {
+    const cases = [_]struct { alert: proto.Alert, expected: anyerror }{
+        .{ .alert = .close_notify, .expected = error.TlsAlertCloseNotify },
+        .{ .alert = .user_canceled, .expected = error.TlsAlertUserCanceled },
+        .{ .alert = .handshake_failure, .expected = error.TlsAlertHandshakeFailure },
+    };
+    for (cases) |c| {
+        const payload = [2]u8{
+            @intFromEnum(proto.Alert.Level.fatal),
+            @intFromEnum(c.alert),
+        };
+        var d: Decoder = .init(.alert, &payload);
+        try testing.expectError(c.expected, d.raiseAlert());
+    }
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -357,6 +357,7 @@ test {
 
     _ = @import("connection.zig");
     _ = @import("cipher.zig");
+    _ = @import("protocol.zig");
     _ = @import("record.zig");
     _ = @import("transcript.zig");
     _ = @import("PrivateKey.zig");


### PR DESCRIPTION
`Alert.fromError` maps every error to an alert, including the `TlsAlert*` ones that mean the peer sent *us* an alert. Those have no entry, so they fall through to `internal_error`: a peer that reports handshake_failure gets told we had an internal error.

The server handshake dodges this by checking whether the error name starts with "TlsAlert". `Connection` does not, it checks for a "Tls" prefix, which matches the alert errors too, so on the connection path we answer every peer alert with internal_error.

`Alert.forLocalError` returns null when there is nothing to say: the peer already reported its own failure, or the transport is gone. Peer alerts are recognised by comparing against the declared `Alert.Error` set rather than by name, so it cannot drift as that set changes, and the name check in handshake_server goes away.

Also fills in mappings that fell through to `internal_error`: bad version, decrypt failure, signature scheme, hello retry request, unsupported fragmented handshake message.

The first commit is separate groundwork. `Alert.parse` read the level and threw it away, and `Decoder.raiseAlert` reported a received `user_canceled` as `TlsAlertCloseNotify` - those are different alerts and user_canceled is not a shutdown.

`ReadFailed`/`WriteFailed` still have to be listed as "say nothing", since they still reach here from the record writer and the certificate parser. Getting rid of them is a later change.