### PR TITLE
don't send an empty server_name extension

### DIFF
--- a/src/handshake_client.zig
+++ b/src/handshake_client.zig
@@ -473,7 +473,9 @@ pub const Handshake = struct {
         try w.extension(.signature_algorithms, common.supported_signature_algorithms);
         try w.extension(.supported_groups, opt.named_groups);
         try w.keyShare(opt.named_groups, shared_keys);
-        try w.serverName(opt.host);
+        if (opt.host.len > 0) {
+            try w.serverName(opt.host);
+        }
         if (opt.alpn_protocols.len > 0) {
             try w.alpn(opt.alpn_protocols);
         }
@@ -1212,7 +1214,13 @@ test "client hello size" {
     try h.initKeys(opt);
     try h.makeClientHello(opt, null);
     try testing.expectEqual(1572 + opt.host.len, h.output.end);
-    //try testing.expectEqual(2794 + opt.host.len, h.stream_writer.end);
+
+    // empty host omits the extension, 9 bytes of server_name framing
+    var no_sni = opt;
+    no_sni.host = "";
+    stream_writer = .fixed(&buffer);
+    try h.makeClientHello(no_sni, null);
+    try testing.expectEqual(1572 - 9, h.output.end);
 }
 
 test "handshake verify server finished message" {


### PR DESCRIPTION
`makeClientHello` writes the `server_name` extension unconditionally, so a client configured with `host = ""` sends a `HostName` of length zero. [RFC 6066 section 3](https://www.rfc-editor.org/rfc/rfc6066#section-3) defines it as `opaque HostName<1..2^16-1>`, and servers can reject the handshake.

Empty host is a supported client configuration: the nonblock tests in `src/root.zig` pass `.host = &.{}`, and `handshake_common.zig` guards host name verification with `if (!h.skip_verify and h.host.len > 0)` while still verifying the chain. The ClientHello writer is the one place that doesn't account for it. Skipping the extension matches the `alpn_protocols` guard two lines later.

The `client hello size` test gains an empty-host case that fails without the fix.