### PR TITLE
Resolve errors from internal readers/writers

### DIFF
--- a/src/PrivateKey.zig
+++ b/src/PrivateKey.zig
@@ -19,8 +19,12 @@ key: union {
 
 const PrivateKey = @This();
 
-pub fn fromFile(gpa: Allocator, file_reader: *std.Io.Reader) !PrivateKey {
-    const buf = try file_reader.allocRemaining(gpa, .limited(1024 * 1024));
+pub fn fromFile(gpa: Allocator, io: std.Io, file: std.Io.File) !PrivateKey {
+    var rdr = file.reader(io, &.{});
+    const buf = rdr.interface.allocRemaining(gpa, .limited(1024 * 1024)) catch |err| switch (err) {
+        error.ReadFailed => return rdr.err orelse error.Unexpected,
+        else => |e| return e,
+    };
     defer gpa.free(buf);
     return try parsePem(buf);
 }

--- a/src/handshake_common.zig
+++ b/src/handshake_common.zig
@@ -62,9 +62,8 @@ pub const CertKeyPair = struct {
         const bundle = try cert.fromFilePath(allocator, io, dir, cert_path);
         const key_file = try dir.openFile(io, key_path, .{});
         defer key_file.close(io);
-        var rdr = key_file.reader(io, &.{});
 
-        const key = try PrivateKey.fromFile(allocator, &rdr.interface);
+        const key = try PrivateKey.fromFile(allocator, io, key_file);
 
         return .{ .bundle = bundle, .key = key, .ecdsa_key_pair = try EcdsaKeyPair.init(key) };
     }
@@ -78,9 +77,8 @@ pub const CertKeyPair = struct {
         const bundle = try cert.fromFilePathAbsolute(allocator, io, cert_path);
         const key_file = try std.Io.Dir.openFileAbsolute(io, key_path, .{});
         defer key_file.close(io);
-        var rdr = key_file.reader(io, &.{});
 
-        const key = try PrivateKey.fromFile(allocator, &rdr.interface);
+        const key = try PrivateKey.fromFile(allocator, io, key_file);
 
         return .{ .bundle = bundle, .key = key, .ecdsa_key_pair = try EcdsaKeyPair.init(key) };
     }

--- a/src/record.zig
+++ b/src/record.zig
@@ -260,24 +260,30 @@ pub const Writer = struct {
         return w.inner.end;
     }
 
+    // `inner` is a fixed writer, so its only failure is a full buffer, and
+    // each of these reserves exactly what it goes on to write. Discharging
+    // that here keeps `WriteFailed` out of the error set of everything built
+    // on top, all the way up through the handshake, so a caller seeing it
+    // knows it came from the transport.
+
     pub fn byte(w: *Writer, b: u8) !void {
         try w.ensureCapacity(1);
-        try w.inner.writeByte(b);
+        w.inner.writeByte(b) catch unreachable;
     }
 
     pub fn slice(w: *Writer, bytes: []const u8) !void {
         try w.ensureCapacity(bytes.len);
-        try w.inner.writeAll(bytes);
+        w.inner.writeAll(bytes) catch unreachable;
     }
 
     pub fn int(w: *Writer, comptime T: type, value: anytype) !void {
         try w.ensureCapacity(@divExact(@typeInfo(T).int.bits, 8));
-        try w.inner.writeInt(T, @intCast(value), .big);
+        w.inner.writeInt(T, @intCast(value), .big) catch unreachable;
     }
 
     pub fn writableArray(w: *Writer, comptime len: usize) !*[len]u8 {
         try w.ensureCapacity(len);
-        return try w.inner.writableArray(len);
+        return w.inner.writableArray(len) catch unreachable;
     }
 
     pub fn enumValue(w: *Writer, value: anytype) !void {
@@ -326,7 +332,7 @@ pub const Writer = struct {
             const key = keys[i];
             try w.enumValue(ng);
             try w.int(u16, key.len);
-            try w.inner.writeAll(key);
+            try w.slice(key);
         }
     }
 
@@ -336,9 +342,9 @@ pub const Writer = struct {
         try w.enumValue(proto.Extension.server_name);
         try w.int(u16, host_len + 5); // byte length of extension payload
         try w.int(u16, host_len + 3); // server_name_list byte count
-        try w.inner.writeByte(0); // name type
+        try w.byte(0); // name type
         try w.int(u16, host_len);
-        try w.inner.writeAll(host);
+        try w.slice(host);
     }
 
     /// ALPN extension (RFC 7301)
@@ -368,7 +374,7 @@ pub const Writer = struct {
         try w.int(u16, identity.len + binder_len + 4 + 2 + 2);
         try w.int(u16, identity.len + 4 + 2);
         try w.int(u16, identity.len);
-        try w.inner.writeAll(identity);
+        try w.slice(identity);
         try w.int(u32, obfuscated_age);
     }
 
@@ -376,7 +382,7 @@ pub const Writer = struct {
     pub fn preSharedKeyBinder(w: *Writer, binder: []const u8) !void {
         try w.int(u16, binder.len + 1);
         try w.int(u8, binder.len);
-        try w.inner.writeAll(binder);
+        try w.slice(binder);
     }
 
     /// tls record
@@ -496,4 +502,21 @@ test "raiseAlert distinguishes the alerts that are not failures" {
         var d: Decoder = .init(.alert, &payload);
         try testing.expectError(c.expected, d.raiseAlert());
     }
+}
+
+test "a write too big for the buffer says so" {
+    var buf: [16]u8 = undefined;
+
+    var w: Writer = .init(&buf);
+    try testing.expectError(error.OutputBufferUndersize, w.serverName("a-host-far-longer-than-the-buffer"));
+
+    w = .init(&buf);
+    try testing.expectError(error.OutputBufferUndersize, w.preSharedKey("an-identity-longer-than-the-buffer", 0, 8));
+
+    w = .init(&buf);
+    try testing.expectError(error.OutputBufferUndersize, w.preSharedKeyBinder("a-binder-longer-than-the-buffer"));
+
+    w = .init(&buf);
+    const key: [32]u8 = @splat(0);
+    try testing.expectError(error.OutputBufferUndersize, w.keyShare(&.{.x25519}, &.{&key}));
 }

--- a/src/rsa/der.zig
+++ b/src/rsa/der.zig
@@ -229,13 +229,20 @@ pub const Element = struct {
         }
     };
 
-    pub const Error = error{ InvalidLength, EndOfStream, ReadFailed };
+    pub const Error = error{ InvalidLength, EndOfStream };
+
+    fn takeByte(reader: *std.Io.Reader) error{EndOfStream}!u8 {
+        return reader.takeByte() catch |err| switch (err) {
+            error.EndOfStream => error.EndOfStream,
+            error.ReadFailed => unreachable,
+        };
+    }
 
     pub fn init(bytes: []const u8, index: Index) Error!Element {
         var reader = std.Io.Reader.fixed(bytes[index..]);
 
-        const identifier = @as(Identifier, @bitCast(try reader.takeByte()));
-        const size_or_len_size = try reader.takeByte();
+        const identifier = @as(Identifier, @bitCast(try takeByte(&reader)));
+        const size_or_len_size = try takeByte(&reader);
 
         var start = index + 2;
         // short form between 0-127
@@ -250,7 +257,10 @@ pub const Element = struct {
         const len_size: u7 = @truncate(size_or_len_size);
         start += len_size;
         if (len_size > @sizeOf(Index)) return error.InvalidLength;
-        const len = try reader.takeVarInt(Index, .big, len_size);
+        const len = reader.takeVarInt(Index, .big, len_size) catch |err| switch (err) {
+            error.EndOfStream => return error.EndOfStream,
+            error.ReadFailed => unreachable,
+        };
         if (len < 128) return error.InvalidLength; // should have used short form
 
         const end = std.math.add(Index, start, len) catch return error.InvalidLength;


### PR DESCRIPTION
std's `Io.Reader`/`Io.Writer` has the unfortunate design, that all errors surface as `ReadFailed`/`WriteFailed`, and you need to reach into the concrete implementation to get the actual cause.

Two problems solved here:

1. Any use of fixed readers/writers leaks these sentinel errors, which will confuse the callers of the library, because if they see `error.WriteFailed`, they don't know where to look for the actual error, they have to assume the error came from the TCP stream reader, but that's not true.

2. Loading a key from a file fails with `error.ReadFailed` if the file I/O is cancelled, or fails for any other reason, but the cancellation is the critical part. The same situation as above, the reader is internal to the library, the caller cannot do anything with the `error.ReadFailed`, and thefore it will not see errors like `error.Canceled` that are only stored in the reader that is gone when the functoin returns.